### PR TITLE
Add importlib-metadata backport install for future server plugin support

### DIFF
--- a/server/04-server-base/requirements.txt
+++ b/server/04-server-base/requirements.txt
@@ -3,3 +3,8 @@ dill>=0.2.8
 wrapt
 pandas
 numba
+
+# importlib-metadata is needed for plugin entrypoints
+# importlib-metadata introduced a select method in 3.6 that the server uses
+# For python version at least 3.8, this functionality is built-in.
+importlib-metadata>=3.6; python_version < '3.8'


### PR DESCRIPTION
In support of https://github.com/deephaven/deephaven-core/issues/1484

importlib-metadata provides a service-loader like mechanism for python, so that the server can easily discover user installed custom types (once we have framework for it).