### PR TITLE
Move both cpp-client and protoc to use debian bullseye

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ Produced for platforms amd64 and arm64.
 
 ### protoc-base
 
-Based on `node:14-buster-slim`, installs support for JS, python, and java protoc generation.
+Based on `node:18-bullseye`, installs support for JS, python, and java protoc generation.
 
 Produced (only) for platform amd64.
 
 ### cpp-client-base
 
-Based on `ubuntu:22.04`, installs libraries needed to build the Deephaven cpp client.
+Based on `debian:bullseye`, installs libraries needed to build the Deephaven cpp client.
 
 Produced (only) for platform amd64.
 

--- a/cpp-client/Dockerfile
+++ b/cpp-client/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 
-FROM ubuntu:22.04
+FROM debian:bullseye
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG BUILD_TYPE=Release
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -102,6 +102,9 @@ target "nginx-noroot-base" {
 
 target "protoc-base" {
     context = "proto/"
+    contexts = {
+        cpp-client-base = "target:cpp-client-base"
+    }
     tags = [ "${REPO_PREFIX}protoc-base:${TAG}" ]
     target = "protoc-base"
 }

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -20,4 +20,4 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh
 COPY --link --from=go-build /go/bin/protoc-gen-go-grpc /opt/protoc-gen-go-grpc
 COPY --link --from=go-build /go/bin/protoc-gen-go /opt/protoc-gen-go
-COPY --link --from=cpp-client-base ./cpp-client/deps/local/grpc/bin /opt/cpp
+COPY --link --from=cpp-client-base ./cpp-client/deps/local/grpc/bin/grpc_cpp_plugin /opt/cpp/grpc_cpp_plugin

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -20,3 +20,4 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh
 COPY --link --from=go-build /go/bin/protoc-gen-go-grpc /opt/protoc-gen-go-grpc
 COPY --link --from=go-build /go/bin/protoc-gen-go /opt/protoc-gen-go
+COPY --link --from=cpp-client-base ./cpp-client/deps/local/grpc/bin /opt/cpp

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; \
 
 # -------------------------------------
 
-FROM node:14 as protoc-base
+FROM node:18-bullseye as protoc-base
 
 ARG DEBIAN_FRONTEND="noninteractive"
 


### PR DESCRIPTION
This lets them share binaries, so that we can copy the cpp protoc plugin from cpp-client dependencies and into the protoc image.

Technically, this is downgrading the cpp-client from a newer distro, but everything still builds cleanly here and in deephaven-core.

The next step would be adding something like this to the protoc image:
```
COPY --from=cpp-client ./cpp-client/deps/local/grpc/bin /opt/cpp
```

I didn't include it here yet because I wasn't sure if we could have cross-image dependencies. It also works well to add it directly in the protoc Dockerfile over in deephaven-core.