### PR TITLE
Ensure the env.sh created by build-dependencies.sh defines CMAKE_BUILD_TYPE

### DIFF
--- a/cpp-client/build-dependencies.sh
+++ b/cpp-client/build-dependencies.sh
@@ -599,6 +599,7 @@ if [ "$GENERATE_ENV" = "yes" ]; then
   echo -n "Creating env.sh..."
   cd $DHDEPS_HOME
   (echo "export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH"
+   echo "export CMAKE_BUILD_TYPE=$BUILD_TYPE"
 #  Ensure this is evaluated not now, but when the generated code is read.
    echo 'export NCPUS=`getconf _NPROCESSORS_ONLN`') > env.sh
   echo DONE.


### PR DESCRIPTION
I had some issues locally due to forgetting to set it, and is error prone because build-dependencies.sh defines it to Debug, which is not the default, and can cause weird linking issues when an installed version of a library exist.  So you can find yourself in a situation like this:

* `build-dependencies.sh` produced only the debugging version of libproto, `libprotobufd.a`
* You ran cmake for the cpp-client without defining CMAKE_BUILD_TYPE=Debug (which is what what used by `build-dependencies.sh`) 
* The machine has an old version of libprotobuf.a installed in /usr/lib.
* You get weird linking errors in your cpp-client build because you are asking for a non-debug version (CMAKE_BUILD_TYPE=Release by default), so the one built by `build-dependencies.sh` can't be used (because it has a different name ending in `d`), so the system one is matched, only for linking, while the headers file used where from the protobuf one created by `build-dependencies.sh`