### PR TITLE
Consolidate all libraries in a single local installation directory.

### DIFF
--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -20,4 +20,4 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh
 COPY --link --from=go-build /go/bin/protoc-gen-go-grpc /opt/protoc-gen-go-grpc
 COPY --link --from=go-build /go/bin/protoc-gen-go /opt/protoc-gen-go
-COPY --link --from=cpp-client-base ./cpp-client/deps/local/grpc/bin/grpc_cpp_plugin /opt/cpp/grpc_cpp_plugin
+COPY --link --from=cpp-client-base ./cpp-client/deps/local/bin/grpc_cpp_plugin /opt/cpp/grpc_cpp_plugin


### PR DESCRIPTION
Corey and myself discussed moving to a single, unified installation directory (what we call `$DHCPP/local`) for all libraries.

So instead of having one subdirectory per library (eg, grpc, protobuf, etc) under `$DHCPP/local`, we will have all the libraries install in `$DHCPP/local` itself.  This simplifies greatly the required settings, at the cost of some flexibility.

The simplification in settings is desirable now that we need LD_LIBRARY_PATH.
The cost in flexibility is the difficulty of "uninstalling" or recompiling a single library.  Before, "uninstalling" a library was essentially removing a single directory.  Now the files are all mixed up, so in the case of a need for reinstalling one library we will have to remove everything and start a full build from scratch.