### PR TITLE
Start work to unify DHE and DHC builds of C++ client, to avoid duplication

### DIFF
--- a/cpp-client/Dockerfile
+++ b/cpp-client/Dockerfile
@@ -1,13 +1,21 @@
 # syntax=docker/dockerfile:1.4
 
-FROM debian:bookworm
+ARG DISTRO_BASE=ubuntu
+ARG DISTRO_VERSION=22.04
+FROM $DISTRO_BASE:$DISTRO_VERSION
+# DISTRO_BASE may be something like 'registry.access.redhat.com/ubi8/ubi-minimal:8.8'
+# In that case DISTRO_BASE_SHORT=ubi
+# (ubi are RedHat provided images for development for RHEL).
+ARG DISTRO_BASE_SHORT=ubuntu
 ARG DEBIAN_FRONTEND="noninteractive"
+ARG PREFIX=/opt/deephaven
 ARG BUILD_TYPE=Release
 
 #
-# Install system dependencies (eg, build tools) for build.
+# Ubuntu/Debian setup + package installs.
 #
 RUN set -eux; \
+    [ "${DISTRO_BASE_SHORT}" = "ubuntu" ] || [ "${DISTRO_BASE_SHORT}" == "debian" ] || exit 0; \
     apt-get -qq update; \
     apt-get -qq -y --no-install-recommends install \
         locales \
@@ -17,16 +25,50 @@ RUN set -eux; \
         g++ \
         cmake \
         make \
+        gzip \
         build-essential \
         zlib1g-dev \
-        libssl-dev; \
+        libssl-dev \
+        dwz \
+        ;
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*
 
 #
+# Fedora/RHEL setup + package installs.
+#
+# Note ubi-minimal (for RHEL) uses 'microdnf' instead of 'dnf'.
+RUN set -eux; \
+    [ "${DISTRO_BASE_SHORT}" = "fedora" ] || [ "${DISTRO_BASE_SHORT}" = "ubi" ] || exit 0; \
+    DNF=`type microdnf >/dev/null 2>&1 && echo 'microdnf --disableplugin=subscription-manager' || echo 'dnf -q'`; \
+    $DNF -y update; \
+    $DNF -y install \
+        git \
+        gcc \
+        gcc-c++ \
+        gzip \
+        cmake \
+        openssl-devel \
+        dwz \
+        ; \
+    $DNF clean all
+
+#
 # Download and build dependent libraries.
 #
+# We use dwz (https://sourceware.org/dwz/) to compress the debug information
+# on builds that include debug information.
+#
+# For Release builds we don't need to keep the source, otherwise
+# a build with debugging information requires the sources to be present.
+#
 RUN --mount=type=bind,source=build-dependencies.sh,target=/build-dependencies.sh \
-    set -eux; mkdir -p /cpp-client/deps; cd /cpp-client/deps; \
-    BUILD_TYPE="${BUILD_TYPE}" /build-dependencies.sh --clean
+    set -eux; \
+    mkdir -p ${PREFIX}; \
+    cd ${PREFIX}; \
+    cp /build-dependencies.sh .; \
+    BUILD_TYPE="${BUILD_TYPE}" ./build-dependencies.sh 2>&1 | gzip -9 > build-dependencies.log.gz; \
+    rm -fr src/*/build_dir src/*/cmake/build_dir; \
+    [ "${BUILD_TYPE}" = "Release" ] || dwz "${PREFIX}/lib"/lib*.so; \
+    [ "${BUILD_TYPE}" != "Release" ] || rm -fr "${PREFIX}/src"

--- a/cpp-client/Dockerfile
+++ b/cpp-client/Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
         zlib1g-dev \
         libssl-dev \
         dwz \
-        ;
+        ; \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
     locale-gen en_US.UTF-8; \
     rm -rf /var/lib/apt/lists/*

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -24,15 +24,49 @@ variable "TAG" {
     default = "latest"
 }
 
-# User for cpp-client, passed to cmake as build type.
-# Typically 'Debug' or 'Release'
-# 'Debug' may be conveniennt in some manual/development
+#
+# BEGIN cpp-client specific variables
+#
+
+# Passed to cmake as CMAKE_BUILD_TYPE
+# Typically 'Debug','Release', or 'RelWithDebInfo'.
+# 'Debug' may be convenient in some manual/development
 # settings, but is considerably more expensive in terms
 # of space and also somewhat more expensive in build time.
 # So we default to 'Release'.
 variable "BUILD_TYPE" {
     default = "Release"
 }
+
+#
+# The base distribution to use for the build.
+# Examples: 'fedora', 'ubuntu', 'registry.access.redhat.com/ubi8/ubi-minimal'
+#
+variable "DISTRO_BASE" {
+    default = "ubuntu"
+}
+
+# A short string to identify the base distribution
+# in conditional code in the Dockerfile.
+# Examples: 'fedora', 'ubuntu', 'ubi'
+variable "DISTRO_BASE_SHORT" {
+    default = "ubuntu"
+}
+
+# The version tag of the DISTRO_BASE to use.
+# Examples: '22.04' (for ubuntu), '38' (for fedora) '8.8' (for ubi).
+variable "DISTRO_VERSION" {
+    default = "22.04"
+}
+
+# The CMAKE_INSTALL_PREFIX for the libraries being built.
+variable "PREFIX" {
+    default = "/opt/deephaven"
+}
+
+#
+# END cpp-client specific variables.
+#
 
 target "protoc-base" {
     context = "proto/"
@@ -48,6 +82,10 @@ target "cpp-client-base" {
     tags = [ "${REPO_PREFIX}cpp-client-base:${TAG}" ]
     args = {
         "BUILD_TYPE" = "${BUILD_TYPE}"
+        "DISTRO_BASE" = "${DISTRO_BASE}"
+        "DISTRO_BASE_SHORT" = "${DISTRO_BASE_SHORT}"
+        "DISTRO_VERSION" = "${DISTRO_VERSION}"
+        "PREFIX" = "${PREFIX}"
     }
 }
 

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -20,4 +20,4 @@ ARG DEBIAN_FRONTEND="noninteractive"
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh
 COPY --link --from=go-build /go/bin/protoc-gen-go-grpc /opt/protoc-gen-go-grpc
 COPY --link --from=go-build /go/bin/protoc-gen-go /opt/protoc-gen-go
-COPY --link --from=cpp-client-base ./cpp-client/deps/bin/grpc_cpp_plugin /opt/cpp/grpc_cpp_plugin
+COPY --link --from=cpp-client-base /opt/deephaven/bin/grpc_cpp_plugin /opt/cpp/grpc_cpp_plugin


### PR DESCRIPTION
As part of the work necessary to deliver the enterprise R client to a customer, we produced dockerized builds supported by 4 dockerfiles for
* Community C++ client
* Community R client
* Enterprise C++ client
* Enterprise R client.
This is already merged in the vermilion branch of DHE and has been used to deliver a bundle to the customer.
I want to remove duplication, and avoid having two dockerfiles for the same thing.  So my plan is:
1 Capture the support for additional platforms that was added and tested in the enterprise build for Community C++ in the base images for cpp-client in community, and remove the enterprise version and refer to this new dockerfile.
2 Add an r-client image in community using the build code for r community in enterprise, remove the enterprise version and instead refer from the enterprise build code to this dockerfile.
3 Use the R client image to implement github (CI) checks that build and run the tests for the community R client.

This PR starts on this work, doing step (1) above.