### PR TITLE
Add tzdata to ubuntu image.

### DIFF
--- a/cpp-client/Dockerfile
+++ b/cpp-client/Dockerfile
@@ -17,8 +17,9 @@ ARG BUILD_TYPE=Release
 RUN set -eux; \
     [ "${DISTRO_BASE_SHORT}" = "ubuntu" ] || [ "${DISTRO_BASE_SHORT}" == "debian" ] || exit 0; \
     apt-get -qq update; \
-    apt-get -qq -y --no-install-recommends install \
+    TZ=Etc/UTC apt-get -qq -y --no-install-recommends install \
         locales \
+        tzdata \
         ca-certificates \
         curl \
         git \


### PR DESCRIPTION
Tests were failing on https://github.com/deephaven/deephaven-core/pull/4551 due to missing tzdata
(which is included by default in debian images).