### PR TITLE
Rename r-client image to cpp-clients-fat; add python+cython support to it.

### DIFF
--- a/cpp-clients-fat/Dockerfile
+++ b/cpp-clients-fat/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux; \
     $DNF clean all
 
 #
-# Python pip3 installs
+# Python pip installs
 #
 RUN set -eux; \
     python3 -m pip install --upgrade pip; \

--- a/cpp-clients-fat/Dockerfile
+++ b/cpp-clients-fat/Dockerfile
@@ -14,8 +14,8 @@ RUN set -eux; \
     [ "${DISTRO_BASE_SHORT}" = "ubuntu" ] || exit 0; \
     apt-get -qq update; \
     apt-get -qq -y --no-install-recommends install \
-        python-3.10-dev \
-        python-3.10-venv; \
+        python3.10-dev \
+        python3.10-venv; \
     rm -fr /var/lib/apt/lists/*
 
 #

--- a/cpp-clients-fat/Dockerfile
+++ b/cpp-clients-fat/Dockerfile
@@ -15,7 +15,8 @@ RUN set -eux; \
     apt-get -qq update; \
     apt-get -qq -y --no-install-recommends install \
         python3.10-dev \
-        python3.10-venv; \
+        python3.10-venv \
+        python3-pip; \
     rm -fr /var/lib/apt/lists/*
 
 #

--- a/cpp-clients-fat/Dockerfile
+++ b/cpp-clients-fat/Dockerfile
@@ -8,6 +8,38 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG PREFIX=/opt/deephaven
 
 #
+# Ubuntu base python install.
+#
+RUN set -eux; \
+    [ "${DISTRO_BASE_SHORT}" = "ubuntu" ] || exit 0; \
+    apt-get -qq update; \
+    apt-get -qq -y --no-install-recommends install \
+        python-3.10-dev \
+        python-3.10-venv; \
+    rm -fr /var/lib/apt/lists/*
+
+#
+# Fedora and RHEL base python install.
+#
+RUN set -eux; \
+    [ "${DISTRO_BASE_SHORT}" = "fedora" ] || \
+      [ "${DISTRO_BASE_SHORT}" = "ubi" ] || \
+      exit 0; \
+    DNF=`type microdnf >/dev/null 2>&1 && echo 'microdnf --disableplugin=subscription-manager' || echo 'dnf -q'`; \
+    $DNF -y update; \
+    $DNF -y install \
+        python3.10-devel \
+        python3-pip; \
+    $DNF clean all
+
+#
+# Python pip3 installs
+#
+RUN set -eux; \
+    python3 -m pip install --upgrade pip; \
+    python3 -m pip install cython
+
+#
 # Ubuntu base R install.
 #
 RUN set -eux; \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,7 +2,7 @@ group "default" {
     targets = [
         "protoc-base",
         "cpp-client-base",
-        "r-client-base",
+        "cpp-clients-fat-base",
     ]
 }
 
@@ -10,7 +10,7 @@ group "release" {
     targets = [
         "protoc-base-release",
         "cpp-client-base-release",
-        "r-client-base-release",
+        "cpp-clients-fat-base-release",
     ]
 }
 
@@ -27,7 +27,7 @@ variable "TAG" {
 }
 
 #
-# cpp-client and r-client variables
+# cpp-client and cpp-clients-fat variables
 #
 
 # Passed to cmake as CMAKE_BUILD_TYPE
@@ -87,9 +87,9 @@ target "cpp-client-base" {
     }
 }
 
-target "r-client-base" {
-    context = "r-client/"
-    tags = [ "${REPO_PREFIX}r-client-base:${TAG}" ]
+target "cpp-clients-fat-base" {
+    context = "cpp-clients-fat/"
+    tags = [ "${REPO_PREFIX}cpp-clients-fat-base:${TAG}" ]
     args = {
         "IMAGE_BASE" = "${REPO_PREFIX}cpp-client-base"
         "IMAGE_TAG" = "${TAG}"
@@ -112,9 +112,9 @@ target "cpp-client-base-release" {
     platforms = [ "linux/amd64" ]
 }
 
-target "r-client-base-release" {
-    inherits = [ "r-client-base" ]
-    cache-from = [ "type=gha,scope=${CACHE_PREFIX}r-client-base" ]
-    cache-to = [ "type=gha,mode=max,scope=${CACHE_PREFIX}r-client-base" ]
+target "cpp-clients-fat-base-release" {
+    inherits = [ "cpp-clients-fat-base" ]
+    cache-from = [ "type=gha,scope=${CACHE_PREFIX}cpp-clients-fat-base" ]
+    cache-to = [ "type=gha,mode=max,scope=${CACHE_PREFIX}cpp-clients-fat-base" ]
     platforms = [ "linux/amd64" ]
 }


### PR DESCRIPTION
In preparation of adding python ticking gradle build and CI support in deephaven-core for py/client-ticking.