### PR TITLE
Add rmarkdown dependency to cpp-clients-multi image

### DIFF
--- a/cpp-clients-multi/Dockerfile
+++ b/cpp-clients-multi/Dockerfile
@@ -121,5 +121,5 @@ RUN set -eux; \
 #
 RUN set -eux; \
     . "${PREFIX}/env.sh"; \
-    echo 'install.packages(c("Rcpp", "arrow", "R6", "dplyr", "testthat", "xml2", "lubridate", "zoo", "knitr"), repos="http://cran.us.r-project.org", quiet=TRUE)' | \
+    echo 'install.packages(c("Rcpp", "arrow", "R6", "dplyr", "testthat", "xml2", "lubridate", "zoo", "knitr", "rmarkdown"), repos="http://cran.us.r-project.org", quiet=TRUE)' | \
       MAKE="make -j${NCPUS}" R --no-save


### PR DESCRIPTION
rmarkdown is the final dependency needed to _build_ the Deephaven R client with the new vignettes.