### PR TITLE
C++ Client: downgrade protobuf to version 3.21.2

### DIFF
--- a/cpp-client/build-dependencies.sh
+++ b/cpp-client/build-dependencies.sh
@@ -561,8 +561,8 @@ if [ "$CLONE_PROTOBUF" = "yes" ]; then
   echo
   echo "*** Cloning protobuf"
   cd $SRC
-  # Previously used version: v3.20.1
-  git clone $GIT_FLAGS -b v3.21.12 --depth 1 "${GITHUB_BASE_URL}/protocolbuffers/protobuf.git"
+  # Previously used version: v3.21.12
+  git clone $GIT_FLAGS -b v3.21.2 --depth 1 "${GITHUB_BASE_URL}/protocolbuffers/protobuf.git"
   echo "*** Cloning protobuf DONE"
 fi
 if [ "$BUILD_PROTOBUF" = "yes" ]; then


### PR DESCRIPTION
This is part of a plan to move all the Deephaven libraries, clients, etc. to the same version.
We would prefer not to use our current standard, 3.20.1 because there is no vcpkg.io build for it in Windows.
We would prefer not to use the latest protobuf build, 3.20.12, because it is broken for JavaScript at the moment.
