### PR TITLE
Change base protobuf version to 3.21.2 and provide a JS plugin

### DIFF
--- a/proto/01-protoc-base/checksums.txt
+++ b/proto/01-protoc-base/checksums.txt
@@ -1,2 +1,3 @@
-44a6b498e996b845edef83864734c0e52f42197e85c9d567af55f4e3ff09d755  protoc-3.20.3-linux-x86_64.zip
+997dfc13189bd0af1051cbc026a095a520e171fbeb0e7460f959ae236b00aa2e  protoc-21.2-linux-x86_64.zip
 cf659ab2367a47590651deb3beb8d6ea177cbd7ff2124ea0d12de06d3181f5c5  protoc-gen-grpc-java-1.50.2-linux-x86_64.exe
+075ed6163fea314c415f67a4af68d1b6dbddc8fa8be35addf74e4c81812a9148  protobuf-javascript-3.21.2-linux-x86_64.zip

--- a/proto/01-protoc-base/install.sh
+++ b/proto/01-protoc-base/install.sh
@@ -23,19 +23,23 @@ python3 -m pip install -q --no-cache-dir --upgrade setuptools
 python3 -m pip install -q --no-cache-dir -r "${__dir}/requirements.txt"
 python3 -m pip list
 
-# Note: should not update past 3.20.x until https://github.com/protocolbuffers/protobuf-javascript/issues/127 is fixed
-
-wget -q "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip"
+wget -q "https://github.com/protocolbuffers/protobuf/releases/download/v21.2/protoc-21.2-linux-x86_64.zip"
 wget -q "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/1.50.2/protoc-gen-grpc-java-1.50.2-linux-x86_64.exe"
+wget -q "https://github.com/protocolbuffers/protobuf-javascript/releases/download/v3.21.2/protobuf-javascript-3.21.2-linux-x86_64.zip"
 sha256sum --check "${__dir}/checksums.txt"
 
-unzip protoc-3.20.3-linux-x86_64.zip -d /opt/protoc
-rm protoc-3.20.3-linux-x86_64.zip
+unzip protoc-21.2-linux-x86_64.zip -d /opt/protoc
+rm protoc-21.2-linux-x86_64.zip
 
 mkdir -p /opt/java/bin
 
 mv protoc-gen-grpc-java-1.50.2-linux-x86_64.exe /opt/java/bin/protoc-gen-grpc-java
 chmod +x /opt/java/bin/protoc-gen-grpc-java
+
+unzip protobuf-javascript-3.21.2-linux-x86_64.zip -d jsplugin_temp
+# move somewhere that is guaranteed to be on the PATH so protoc can find it
+mv jsplugin_temp/bin/protoc-gen-js /usr/local/bin/
+rm -r protobuf-javascript-3.21.2-linux-x86_64.zip jsplugin_temp
 
 mkdir -p /usr/src/app
 cp "${__dir}/package.json" /usr/src/app

--- a/proto/01-protoc-base/package-lock.json
+++ b/proto/01-protoc-base/package-lock.json
@@ -3,9 +3,9 @@
   "lockfileVersion": 1,
   "dependencies": {
     "google-protobuf": {
-      "version": "3.20.1",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.20.1.tgz",
-      "integrity": "sha512-XMf1+O32FjYIV3CYu6Tuh5PNbfNEU5Xu22X+Xkdb/DUexFlCzhvv7d5Iirm4AOwn8lv4al1YvIhzGrg2j9Zfzw=="
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
     },
     "ts-protoc-gen": {
       "version": "0.15.0",

--- a/proto/01-protoc-base/package.json
+++ b/proto/01-protoc-base/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "google-protobuf": "~3.20.1",
+    "google-protobuf": "~3.21.2",
     "ts-protoc-gen": "^0.15.0"
   },
   "engines": {


### PR DESCRIPTION
Note that you don't *need* to tell protoc where the JS plugin is, so long as it can find `protoc-gen-js` somewhere on the PATH.

The approach I took here was to dump the `protoc-gen-js` executable into `/usr/local/bin`. Other destinations are certainly possible.

Tested on my local image registry. Did both a positive and negative test.
The positive test is: I ran this command locally and it built Deephaven.
The negative test is: I made an image but I renamed the JS executable to `/usr/local/bin/cantseeme`.

The positive test passed (brought up Deephaven) and the negative test failed.

The testing command (in the Deephaven Core repo) was
```
./gradlew prepareCompose -Panonymous && docker-compose up --build
```