### PR TITLE
Add dependencies into proto image to support documentation generation

### DIFF
--- a/proto/01-protoc-base/checksums.txt
+++ b/proto/01-protoc-base/checksums.txt
@@ -1,3 +1,4 @@
 f853e691868d0557425ea290bf7ba6384eef2fa9b04c323afab49a770ba9da80  protoc-25.3-linux-x86_64.zip
 b0f50f6a857c3e17f7a83ce90d9f877640381100289fedc4658dc47d69bc7f36  protoc-gen-grpc-java-1.63.1-linux-x86_64.exe
 075ed6163fea314c415f67a4af68d1b6dbddc8fa8be35addf74e4c81812a9148  protobuf-javascript-3.21.2-linux-x86_64.zip
+47cd72b07e6dab3408d686a65d37d3a6ab616da7d8b564b2bd2a2963a72b72fd  protoc-gen-doc_1.5.1_linux_amd64.tar.gz

--- a/proto/01-protoc-base/install.sh
+++ b/proto/01-protoc-base/install.sh
@@ -43,9 +43,6 @@ rm "$pbuf_zip"
 tar -xzf "protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz" -C /usr/local/bin
 rm "protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz"
 
-# move protoc to PATH so it can be used in doc generation
-mv /opt/protoc/bin/protoc /usr/local/bin/
-
 mkdir -p /opt/java/bin
 
 mv "protoc-gen-grpc-java-${java_plugin_ver}-linux-x86_64.exe" /opt/java/bin/protoc-gen-grpc-java

--- a/proto/01-protoc-base/install.sh
+++ b/proto/01-protoc-base/install.sh
@@ -31,10 +31,11 @@ wget -q "https://repo1.maven.org/maven2/io/grpc/protoc-gen-grpc-java/${java_plug
 
 js_ver=3.21.2
 wget -q "https://github.com/protocolbuffers/protobuf-javascript/releases/download/v${js_ver}/protobuf-javascript-${js_ver}-linux-x86_64.zip"
-sha256sum --check "${__dir}/checksums.txt"
 
 doc_plugin_ver=1.5.1
 wget -q "https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${doc_plugin_ver}/protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz"
+
+sha256sum --check "${__dir}/checksums.txt"
 
 pbuf_zip=protoc-${pbuf_ver}-linux-x86_64.zip
 unzip "$pbuf_zip" -d /opt/protoc

--- a/proto/01-protoc-base/install.sh
+++ b/proto/01-protoc-base/install.sh
@@ -33,9 +33,18 @@ js_ver=3.21.2
 wget -q "https://github.com/protocolbuffers/protobuf-javascript/releases/download/v${js_ver}/protobuf-javascript-${js_ver}-linux-x86_64.zip"
 sha256sum --check "${__dir}/checksums.txt"
 
+doc_plugin_ver=1.5.1
+wget -q "https://github.com/pseudomuto/protoc-gen-doc/releases/download/v${doc_plugin_ver}/protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz"
+
 pbuf_zip=protoc-${pbuf_ver}-linux-x86_64.zip
 unzip "$pbuf_zip" -d /opt/protoc
 rm "$pbuf_zip"
+
+tar -xzf "protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz" -C /usr/local/bin
+rm "protoc-gen-doc_${doc_plugin_ver}_linux_amd64.tar.gz"
+
+# move protoc to PATH so it can be used in doc generation
+mv /opt/protoc/bin/protoc /usr/local/bin/
 
 mkdir -p /opt/java/bin
 

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -2,7 +2,7 @@
 
 # -------------------------------------
 
-FROM cpp-client-base as protoc-base
+FROM --platform=linux/amd64 cpp-client-base as protoc-base
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG PROTOC_GEN_GO_VERSION=v1.28
@@ -11,6 +11,7 @@ ARG PROTOC_GEN_DOC_VERSION=v1.5.1
 ARG PROTOC_VERSION=3.17.3
 
 ENV GOPATH=/opt/go
+ENV PATH=$GOPATH/bin:$PATH
 
 RUN set -eux; \
     mkdir -p ${GOPATH}; \

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -7,11 +7,8 @@ FROM cpp-client-base as protoc-base
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
-ARG PROTOC_GEN_DOC_VERSION=v1.5.1
-ARG PROTOC_VERSION=3.17.3
 
 ENV GOPATH=/opt/go
-ENV PATH=$GOPATH/bin:$PATH
 
 RUN set -eux; \
     mkdir -p ${GOPATH}; \
@@ -20,13 +17,8 @@ RUN set -eux; \
       golang \
       nodejs \
       npm \
-      unzip \
       ; \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}; \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}; \
-    go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@${PROTOC_GEN_DOC_VERSION}; \
-    curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
-    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local; \
-    rm protoc-${PROTOC_VERSION}-linux-x86_64.zip
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
 
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -8,6 +8,7 @@ ARG DEBIAN_FRONTEND="noninteractive"
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
 ARG PROTOC_GEN_DOC_VERSION=v1.5.1
+ARG PROTOC_VERSION=3.17.3
 
 ENV GOPATH=/opt/go
 
@@ -18,9 +19,13 @@ RUN set -eux; \
       golang \
       nodejs \
       npm \
+      unzip \
       ; \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}; \
     go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}; \
-    go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@${PROTOC_GEN_DOC_VERSION}
+    go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@${PROTOC_GEN_DOC_VERSION}; \
+    curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-linux-x86_64.zip; \
+    unzip protoc-${PROTOC_VERSION}-linux-x86_64.zip -d /usr/local; \
+    rm protoc-${PROTOC_VERSION}-linux-x86_64.zip
 
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -2,7 +2,7 @@
 
 # -------------------------------------
 
-FROM --platform=linux/amd64 cpp-client-base as protoc-base
+FROM cpp-client-base as protoc-base
 
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG PROTOC_GEN_GO_VERSION=v1.28

--- a/proto/Dockerfile
+++ b/proto/Dockerfile
@@ -7,6 +7,7 @@ FROM cpp-client-base as protoc-base
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG PROTOC_GEN_GO_VERSION=v1.28
 ARG PROTOC_GEN_GO_GRPC_VERSION=v1.2
+ARG PROTOC_GEN_DOC_VERSION=v1.5.1
 
 ENV GOPATH=/opt/go
 
@@ -19,6 +20,7 @@ RUN set -eux; \
       npm \
       ; \
     go install google.golang.org/protobuf/cmd/protoc-gen-go@${PROTOC_GEN_GO_VERSION}; \
-    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}
+    go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@${PROTOC_GEN_GO_GRPC_VERSION}; \
+    go install github.com/pseudomuto/protoc-gen-doc/cmd/protoc-gen-doc@${PROTOC_GEN_DOC_VERSION}
 
 RUN --mount=type=bind,source=./01-protoc-base,target=./01-protoc-base ./01-protoc-base/install.sh


### PR DESCRIPTION
We want to autogenerate protobuf docs in DHC. This is Devin's recommended step 1 for accomplishing this. The container this change creates was tested and confirmed to have the structure needed to do the doc generation.