### PR TITLE
Remove checkout step, not necessary anymore with bake-action v6

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -19,9 +19,6 @@ jobs:
 
     runs-on: ubuntu-24.04
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 


### PR DESCRIPTION
https://github.com/docker/bake-action/releases/tag/v6.0.0

https://github.com/docker/bake-action/tree/v6.0.0?tab=readme-ov-file#git-context