### PR TITLE
fix: DH-22059: Fix build break introduced by recent changes

### DIFF
--- a/cpp-client/Dockerfile
+++ b/cpp-client/Dockerfile
@@ -7,6 +7,7 @@ FROM $DISTRO_BASE:$DISTRO_VERSION
 # In that case DISTRO_BASE_SHORT=ubi
 # (ubi are RedHat provided images for development for RHEL).
 ARG DISTRO_BASE_SHORT=ubuntu
+ARG DISTRO_VERSION
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG PREFIX=/opt/deephaven
 ARG BUILD_TYPE=Release
@@ -34,6 +35,24 @@ RUN set -eux; \
         ; \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen; \
     locale-gen en_US.UTF-8; \
+    rm -rf /var/lib/apt/lists/*
+
+#
+# For Ubuntu 22.04 specifically, update cmake to newer version, but not too new:
+# Ubuntu 22.04 ships with cmake 3.22.1 but Arrow now requires 3.25+.
+# We can't update to "latest" cmake 4.x because this conflicts with
+# a cmake_minimum_version from cflags that is too old to be supported by cmake 4.x.
+# So we (somewhat arbitrarily) pin to 3.31.11
+#
+RUN set -eux; \
+    [ "${DISTRO_BASE_SHORT}" = "ubuntu" ] && [ "${DISTRO_VERSION}" = "22.04" ] || exit 0; \
+    apt-get update && apt-get install -y --no-install-recommends ca-certificates gpg wget; \
+    wget -qO- https://apt.kitware.com/keys/kitware-archive-latest.asc \
+        | gpg --dearmor -o /usr/share/keyrings/kitware-archive-keyring.gpg; \
+    echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main" \
+        > /etc/apt/sources.list.d/kitware.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends cmake=3.31.11-0kitware1ubuntu22.04.1 cmake-data=3.31.11-0kitware1ubuntu22.04.1; \
     rm -rf /var/lib/apt/lists/*
 
 #
@@ -69,7 +88,8 @@ RUN --mount=type=bind,source=build-dependencies.sh,target=/build-dependencies.sh
     mkdir -p ${PREFIX}; \
     cd ${PREFIX}; \
     cp /build-dependencies.sh .; \
-    BUILD_TYPE="${BUILD_TYPE}" ./build-dependencies.sh 2>&1 | gzip -9 > build-dependencies.log.gz; \
+    BUILD_TYPE="${BUILD_TYPE}" ./build-dependencies.sh > build-dependencies.log 2>&1; \
+    gzip -9 build-dependencies.log; \
     rm -fr src/*/build_dir src/*/cmake/build_dir; \
     [ "${BUILD_TYPE}" = "Release" ] || dwz "${PREFIX}/lib"/lib*.so; \
     [ "${BUILD_TYPE}" != "Release" ] || rm -fr "${PREFIX}/src"


### PR DESCRIPTION
This PR includes two things:

1. On Ubuntu 22.04 it installs a newer version of cmake. The default cmake on Ubuntu 22.04 is so old that it breaks the gflags build
2. Splits the logging of build-dependencies.sh and the gzipping of that log.

The purpose of item 2 is to avoid a problem we had where build-dependencies.sh had an error but the Docker script kept going.  We had a commadn like

`build-dependencies.sh | gzip -9 > blah.log.gz`

The problem is that even though buid-dependencies.sh has an error, gzip won't have an error, and then the script won't stop here. This will lead to confusing behavior later.

Shells like `bash` have the `pipefail` option for this. However the shell that comes with Docker doesn't support pipefail. Rather than add increasingly more complicated commands here, we just separate the log creation and the gzipping.